### PR TITLE
Update link of api service to existing devcontainer.json

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - .:/workspace:cached
     command: sleep infinity
     links:
-      - node-container
+      - app
     # ...
 
   app:


### PR DESCRIPTION
As I was following the video on YouTube I realised that docker compose could not run successfully.
The following change fixes this problem and should be included in the original repo as well.
