### PR TITLE
Update API Service to Link with App Container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - .:/workspace:cached
     command: sleep infinity
     links:
-      - node-container
+      - app
     # ...
 
   app:


### PR DESCRIPTION
the link to `node-container` has been replaced by a link to the `app` service